### PR TITLE
Fetch GJ trophies (Part 1/2)

### DIFF
--- a/tentools/api/FlxGameJolt.hx
+++ b/tentools/api/FlxGameJolt.hx
@@ -168,6 +168,11 @@ class FlxGameJolt
 	 * URLLoader object for sending URL requests.
 	 */
 	static var _loader:URLLoader;
+	
+	/**
+	 * A string map that contains what is returned from GameJolt servers.
+	 */	
+	static var returnMap:Map<String, String> = new Map<String, String>();
 
 	/**
 	 * Various common strings required by the API's HTTP values.
@@ -726,8 +731,7 @@ class FlxGameJolt
 			#end
 			return;
 		}
-
-		var returnMap:Map<String, String> = new Map<String, String>();
+		
 		var stringArray:Array<String> = Std.string((cast e.currentTarget).data).split("\r");
 
 		// this regex will remove line breaks and quotes down below


### PR DESCRIPTION
This makes returnMap variable available (still private tho), instead for only a single function.

This change allows the GameJolt class in the [other repository](https://github.com/TentaRJ/GameJolt-FNF-Integration) to access the returned variables, and allowing more functions to be added (ex. fetch GameJolt trophies, the main purpose of this PR).